### PR TITLE
consensus: make powLimit configurable per chain again

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -95,8 +95,8 @@ public:
         consensus.CSVHeight    = 1; 
         consensus.SegwitHeight = 1; 
         consensus.MinBIP9WarningHeight = 1; // segwit activation height + miner confirmation window
-        consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.nPowTargetTimespan = 14ULL * 24ULL * 60ULL * 60ULL; // 14 Days * 24 Hours * 60 Minutes * 60 Seconds |-> Seconds in 2 weeks. 
+        consensus.powLimit = 210;
+        consensus.nPowTargetTimespan = 14ULL * 24ULL * 60ULL * 60ULL; // 14 Days * 24 Hours * 60 Minutes * 60 Seconds |-> Seconds in 2 weeks.
         consensus.nPowTargetSpacing  =   30 * 60;                     // 30 Minutes * 60 Seconds                      |-> Seconds in 30 minutes
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting  = false;
@@ -206,7 +206,7 @@ public:
         consensus.CSVHeight = 1; 
         consensus.SegwitHeight = 1; 
         consensus.MinBIP9WarningHeight = 1; // segwit activation height + miner confirmation window
-        consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.powLimit = 175;
         consensus.nPowTargetTimespan = 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 5 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
@@ -354,7 +354,7 @@ public:
         consensus.nRuleChangeActivationThreshold = 1815; // 90% of 2016
         consensus.nMinerConfirmationWindow = 672; // nPowTargetTimespan / nPowTargetSpacing
         consensus.MinBIP9WarningHeight = 0;
-        consensus.powLimit = uint256S("00000377ae000000000000000000000000000000000000000000000000000000");
+        consensus.powLimit = 32;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
@@ -419,7 +419,7 @@ public:
         consensus.CSVHeight = 1; 
         consensus.SegwitHeight = 1; 
         consensus.MinBIP9WarningHeight = 0;
-        consensus.powLimit = uint256S("000000000000000000000000000000000000000000000000000000000000000");
+        consensus.powLimit = 32;
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 30 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -96,7 +96,7 @@ struct Params {
     uint32_t nMinerConfirmationWindow;
     BIP9Deployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS];
     /** Proof of work parameters */
-    uint256 powLimit;
+    uint16_t powLimit;
     bool fPowAllowMinDifficultyBlocks;
     bool fPowNoRetargeting;
     int64_t nPowTargetSpacing;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -30,7 +30,6 @@
 uint16_t GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
     assert(pindexLast != nullptr);
-    uint16_t nProofOfWorkLimit = 32; 
 
     // Only change once per difficulty adjustment interval
     if ((pindexLast->nHeight+1) % params.DifficultyAdjustmentInterval() != 0)
@@ -41,14 +40,17 @@ uint16_t GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *
             // If the new block's timestamp is more than 2* 10 minutes
             // then allow mining of a min-difficulty block.
             if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*2){
-                return nProofOfWorkLimit;
+                return params.powLimit;
             }
             else
             {
                 // Return the last non-special-min-difficulty-rules-block
                 const CBlockIndex* pindex = pindexLast;
-                while (pindex->pprev && pindex->nHeight % params.DifficultyAdjustmentInterval() != 0 && pindex->nBits == nProofOfWorkLimit)
+                while (pindex->pprev && pindex->nHeight % params.DifficultyAdjustmentInterval() != 0 &&
+                       pindex->nBits == params.powLimit)
+                {
                     pindex = pindex->pprev;
+                }
                 return pindex->nBits;
             }
         }


### PR DESCRIPTION
Reuses `consensus.powLimit` as `uint16_t` so that it is configurable per chain rather than a global value for all chains. This allows regtest and signet to stay ez, testnet to not be too fast, and mainnet to retain slow blocks