### PR TITLE
cleanup: move consensus related magic numbers to consensus params

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -96,6 +96,8 @@ public:
         consensus.SegwitHeight = 1; 
         consensus.MinBIP9WarningHeight = 1; // segwit activation height + miner confirmation window
         consensus.powLimit = 210;
+        consensus.maxLilt = 0.40f;
+        consensus.maxRetargetDelta = 4;
         consensus.nPowTargetTimespan = 14ULL * 24ULL * 60ULL * 60ULL; // 14 Days * 24 Hours * 60 Minutes * 60 Seconds |-> Seconds in 2 weeks.
         consensus.nPowTargetSpacing  =   30 * 60;                     // 30 Minutes * 60 Seconds                      |-> Seconds in 30 minutes
         consensus.fPowAllowMinDifficultyBlocks = false;
@@ -207,6 +209,8 @@ public:
         consensus.SegwitHeight = 1; 
         consensus.MinBIP9WarningHeight = 1; // segwit activation height + miner confirmation window
         consensus.powLimit = 175;
+        consensus.maxLilt = 0.40f;
+        consensus.maxRetargetDelta = 4;
         consensus.nPowTargetTimespan = 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 5 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
@@ -355,6 +359,8 @@ public:
         consensus.nMinerConfirmationWindow = 672; // nPowTargetTimespan / nPowTargetSpacing
         consensus.MinBIP9WarningHeight = 0;
         consensus.powLimit = 32;
+        consensus.maxLilt = 0.40f;
+        consensus.maxRetargetDelta = 4;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
@@ -420,6 +426,8 @@ public:
         consensus.SegwitHeight = 1; 
         consensus.MinBIP9WarningHeight = 0;
         consensus.powLimit = 32;
+        consensus.maxLilt = 0.40f;
+        consensus.maxRetargetDelta = 4;
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 30 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -101,6 +101,8 @@ struct Params {
     bool fPowNoRetargeting;
     int64_t nPowTargetSpacing;
     int64_t nPowTargetTimespan;
+    double maxLilt; // The extrema of timespan deviation
+    int32_t maxRetargetDelta; // The extrema of the retargeting delta
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
     /** The best chain should have at least this much work */
     uint256 nMinimumChainWork;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -76,15 +76,15 @@ uint16_t CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirst
     const double  nPeriodTimeProportionConsumed = (double)nActualTimespan/(double)params.nPowTargetTimespan;    
 
     //Handle extremes
-    if( nPeriodTimeProportionConsumed >= 1.40f)
-        return (int32_t)pindexLast->nBits - 4;
-    if( nPeriodTimeProportionConsumed <= 0.60)
-        return (int32_t)pindexLast->nBits + 4;
+    if( nPeriodTimeProportionConsumed >= (1.00f + params.maxLilt))
+        return (int32_t)pindexLast->nBits - params.maxRetargetDelta;
+    if( nPeriodTimeProportionConsumed <= (1.00f - params.maxLilt))
+        return (int32_t)pindexLast->nBits + params.maxRetargetDelta;
 
     //Compute Retargeting function
-    const int32_t condition = nPeriodTimeProportionConsumed > 1; 
-    const int32_t maxAdjust = ( condition ) ? -4: 4;
-    const double         Fx = (1.0f)/(2*nPeriodTimeProportionConsumed - 1 - 2*condition) - 1 + 2*condition; 
+    const int32_t condition = nPeriodTimeProportionConsumed > 1;
+    const int32_t maxAdjust = ( condition ) ? -params.maxRetargetDelta : params.maxRetargetDelta;
+    const double         Fx = (1.0f)/(2*nPeriodTimeProportionConsumed - 1 - 2*condition) - 1 + 2*condition;
     const int32_t   roundFx = round( Fx );
     const int32_t nRetarget = condition ? std::max( maxAdjust, roundFx ) : std::min( maxAdjust, roundFx ) ;
 


### PR DESCRIPTION
Moves hardcoded lilt and retarget delta from pow.cpp to be part of chainparams.cpp for clarity.

- `maxRetargetDelta` is the absolute maximum deviation we apply to difficulty when retargeting.
- `maxLilt` is the absolute maximum deviation of actual time versus target time that we take into account - if this is exceeded in either direction, we simply apply `maxRetargetDelta` in either direction

This doesn't change parametrization, we only change parameter structure.