### PR TITLE
cleanup: make pow.cpp functions use LogPrint and LogPrintf

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -158,6 +158,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::VALIDATION, "validation"},
     {BCLog::I2P, "i2p"},
     {BCLog::IPC, "ipc"},
+    {BCLog::POW, "pow"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -59,6 +59,7 @@ namespace BCLog {
         VALIDATION  = (1 << 21),
         I2P         = (1 << 22),
         IPC         = (1 << 23),
+        POW         = (1 << 24),
         ALL         = ~(uint32_t)0,
     };
 


### PR DESCRIPTION
- debug values go into new category `pow` with `LogPrint`
- errors go into the main log with `LogPrintf`

Verbose pow log can be printed in log by adding `-debug=pow`
