### PR TITLE
build: allow libgmp dependency

### DIFF
--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -84,7 +84,8 @@ ELF_ALLOWED_LIBRARIES = {
 'libxkbcommon-x11.so.0', # keyboard keymapping
 'libfontconfig.so.1', # font support
 'libfreetype.so.6', # font parsing
-'libdl.so.2' # programming interface to dynamic linker
+'libdl.so.2', # programming interface to dynamic linker
+'libgmp.so.10', # libgmp
 }
 
 MACHO_ALLOWED_LIBRARIES = {


### PR DESCRIPTION
This allows released binaries to require libgmp to be preinstalled on the system. Can be removed later when we find a way to statically compile gmp in from `depends`