### PR TITLE
consensus: fix bug where taproot isn't a buried deployment

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -24,7 +24,7 @@ enum BuriedDeployment : int16_t {
     DEPLOYMENT_SEGWIT,
     DEPLOYMENT_TAPROOT,
 };
-constexpr bool ValidDeployment(BuriedDeployment dep) { return dep <= DEPLOYMENT_SEGWIT; }
+constexpr bool ValidDeployment(BuriedDeployment dep) { return dep <= DEPLOYMENT_TAPROOT; }
 
 enum DeploymentPos : uint16_t {
     DEPLOYMENT_TESTDUMMY,


### PR DESCRIPTION
Not only should `DEPLOYMENT_TAPROOT` be in the `BuriedDeployment` enum, it should also be evaluating as the last valid buried deployment in the `ValidDeployment` expr.