### PR TITLE
build: fix the guix buildname for archive output

### DIFF
--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -50,7 +50,7 @@ fi
 ################
 
 VERSION="${FORCE_VERSION:-$(git_head_version)}"
-DISTNAME="${DISTNAME:-bitcoin-${VERSION}}"
+DISTNAME="${DISTNAME:-factorn-${VERSION}}"
 
 version_base_prefix="${PWD}/guix-build-"
 VERSION_BASE="${version_base_prefix}${VERSION}"  # TOP


### PR DESCRIPTION
currently says "bitcoin" in the archive name, no bueno. 