### PR TITLE
cleanup: fix pow.cpp header usage

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -170,6 +170,7 @@ BITCOIN_CORE_H = \
   interfaces/wallet.h \
   key.h \
   key_io.h \
+  libpopcnt.h \
   logging.h \
   logging/timer.h \
   mapport.h \

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -16,17 +16,17 @@
 #include <cmath>
 
 //Blake2b, Scrypt and SHA3-512
-#include "cryptopp/cryptlib.h"
-#include "cryptopp/sha3.h"
-#include "cryptopp/whrlpool.h"
-#include "cryptopp/scrypt.h"
-#include "cryptopp/secblock.h"
-#include "cryptopp/blake2.h"
-#include "cryptopp/hex.h"
-#include "cryptopp/files.h"
+#include <cryptopp/cryptlib.h>
+#include <cryptopp/sha3.h>
+#include <cryptopp/whrlpool.h>
+#include <cryptopp/scrypt.h>
+#include <cryptopp/secblock.h>
+#include <cryptopp/blake2.h>
+#include <cryptopp/hex.h>
+#include <cryptopp/files.h>
 
 //Fancy popcount implementation
-#include "libpopcnt.h"
+#include <libpopcnt.h>
 
 uint16_t GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {


### PR DESCRIPTION
Makes `pow.cpp` header includes use bracket syntax and adds `libpopcnt.h` to the Makefile so that strict compiler settings don't bug out.

This fixes the focal CI build at the expense of more linter errors (because it will apply code style rules to `libpopcnt.h`)