### PR TITLE
Fix deadpool announcement transaction selection + other fixes

### DIFF
--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include <algorithm>
+#include <stdexcept>
 #ifdef ARENA_DEBUG
 #include <iomanip>
 #include <iostream>

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -412,7 +412,7 @@ public:
         double a_mod_fee, a_size, b_mod_fee, b_size;
 
         CAmount a_burned = a.GetBurnAmountWithAncestors();
-        CAmount b_burned = a.GetBurnAmountWithAncestors();
+        CAmount b_burned = b.GetBurnAmountWithAncestors();
 
         if (a_burned != b_burned) {
             return a_burned > b_burned;

--- a/src/util/bip32.h
+++ b/src/util/bip32.h
@@ -6,6 +6,7 @@
 #define BITCOIN_UTIL_BIP32_H
 
 #include <attributes.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <cstring>
 #include <locale>
 #include <sstream>


### PR DESCRIPTION
In `BlockAssembler`, the set of existing announcements (`vIncludedAnnounces`) isn't updated until a "package" of transactions is added to the assembled block  
Therefore, when 2 announcements with same deadpool id appear in the same package of transactions, it slips through the existing `BlockAssembler::TestPackageTransactions` check and makes `ContextualCheckBlock` error out with `dp-mult-ann, more than one announcement for a single deadpool entry`.  
This is causing existing versions of the node to fail to handle `getblocktemplate` requests, since there's currently 2 announcements on the same N in the mempool. This issue have brought down nearly all active miners on the network who upgraded their node.
This PR fixes the issue by adding a `packageAnnounces` variable in `BlockAssembler::TestPackageTransactions` and using it to check if the same deadpool id appeared twice in the current package

Some additional fixes included in this PR:
- Typo fixed in `CompareTxMemPoolEntryByAncestorBurnFee` which was breaking transaction sorting by burnt fee
- Added some missing `#include` directives, which were causing the node to fail to compile on newer GCC versions (for instance, it doesn't compile with GCC 14.2.1 without the fix)