### PR TITLE
depends: boost 1_86_0

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,8 +1,8 @@
 package=boost
-$(package)_version=1_71_0
-$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/$(subst _,.,$($(package)_version))/source/
+$(package)_version=1_86_0
+$(package)_download_path=https://archives.boost.io/release/$(subst _,.,$($(package)_version))/source/
 $(package)_file_name=boost_$($(package)_version).tar.bz2
-$(package)_sha256_hash=d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee
+$(package)_sha256_hash=1bed88e40401b2cb7a1f76d4bab499e352fa4d0c5f31c0dbae64e24d34d7513b
 $(package)_dependencies=native_b2
 
 define $(package)_set_vars

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -624,7 +624,7 @@ bool BerkeleyDatabase::Backup(const std::string& strDest) const
                         return false;
                     }
 
-                    fs::copy_file(pathSrc, pathDest, fs::copy_option::overwrite_if_exists);
+                    fs::copy_file(pathSrc, pathDest, fs::copy_options::overwrite_existing);
                     LogPrintf("copied %s to %s\n", strFile, pathDest.string());
                     return true;
                 } catch (const fs::filesystem_error& e) {

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -19,7 +19,7 @@ std::vector<fs::path> ListDatabases(const fs::path& wallet_dir)
     for (auto it = fs::recursive_directory_iterator(wallet_dir, ec); it != fs::recursive_directory_iterator(); it.increment(ec)) {
         if (ec) {
             if (fs::is_directory(*it)) {
-                it.no_push();
+                it.disable_recursion_pending();
                 LogPrintf("%s: %s %s -- skipping.\n", __func__, ec.message(), it->path().string());
             } else {
                 LogPrintf("%s: %s %s\n", __func__, ec.message(), it->path().string());
@@ -36,7 +36,7 @@ std::vector<fs::path> ListDatabases(const fs::path& wallet_dir)
                 (IsBDBFile(BDBDataFile(it->path())) || IsSQLiteFile(SQLiteDataFile(it->path())))) {
                 // Found a directory which contains wallet.dat btree file, add it as a wallet.
                 paths.emplace_back(path);
-            } else if (it.level() == 0 && it->symlink_status().type() == fs::regular_file && IsBDBFile(it->path())) {
+            } else if (it.depth() == 0 && it->symlink_status().type() == fs::regular_file && IsBDBFile(it->path())) {
                 if (it->path().filename() == "wallet.dat") {
                     // Found top-level wallet.dat btree file, add top level directory ""
                     // as a wallet.
@@ -51,7 +51,7 @@ std::vector<fs::path> ListDatabases(const fs::path& wallet_dir)
             }
         } catch (const std::exception& e) {
             LogPrintf("%s: Error scanning %s: %s\n", __func__, it->path().string(), e.what());
-            it.no_push();
+            it.disable_recursion_pending();
         }
     }
 


### PR DESCRIPTION
Pin boost v1.86 as the default and fix inherent `boost::filesystem` changes.

This helps compilation using depends for (arm) macOS since Xcode 16 (=Sonoma) because boost 1.71 is too old and misses facilities to deal with some non-backward compatibility (most prominently: `unary_function`)

- Change pinned version to `1_86_0`
- Change download url to no longer use jfrog's repo but the more recent `archives.boost.io` as linked from [boost.org](https://www.boost.org/users/history/version_1_86_0.html)
- Incorporate [boost::filesystem breaking changes](https://www.boost.org/doc/libs/1_86_0/libs/filesystem/doc/deprecated.html):
    - `recursive_directory_iterator::level()` -> `depth()`
    - `recursive_directory_iterator::no_push()` -> `disable_recursion_pending()`
    - `copy_option::overwrite_if_exists` -> `copy_options::overwrite_existing`